### PR TITLE
Support #17737 Upgrade to SpringBoot 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.8.RELEASE</version>
+		<version>2.2.1.RELEASE</version>
 	</parent>
 
 	<properties>
@@ -40,8 +40,6 @@
 		<checkstyle.version>8.23</checkstyle.version>
 		<asciidoctor-maven-plugin.version>1.5.7.1</asciidoctor-maven-plugin.version>
 		<asciidoctorj.diagram.version>1.5.18</asciidoctorj.diagram.version>
-		<!-- rest assured 4.0.0 is required for API testing -->
-		<rest-assured.version>4.0.0</rest-assured.version>
 		<justify.version>0.17.0</justify.version>
 		<javax.json.version>1.1.3</javax.json.version>
 		<junit-platform-launcher.version>1.4.0</junit-platform-launcher.version>
@@ -189,25 +187,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<!--JUnit Jupiter Engine to depend on the JUnit5 engine and JUnit 5 API -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!--We need to override the platform-launcher provided by SpringBoot otherwise tests are not working in Eclipse-->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-launcher</artifactId>
-			<version>${junit-platform-launcher.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.rest-assured</groupId>
@@ -227,8 +206,8 @@
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured-all</artifactId>
-			<version>${rest-assured.version}</version>
 			<scope>test</scope>
+			<version>${rest-assured.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.leadpony.justify</groupId>
@@ -251,6 +230,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<includeSystemScope>true</includeSystemScope>
+					<fork>false</fork>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
-Updated SpringBoot to 2.2.1.
-Removed rest-assured specific version
-SpringBoot uses JUnit 5 so we can remove junit5 dependencies