### PR TITLE
Support #18401 API: Increase dc_format column's max length

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
@@ -216,6 +216,7 @@ public class ObjectStoreMetadata implements java.io.Serializable, UniqueObj {
   }
   
   @Column(name = "dc_format")
+  @Size(max = 150)
   public String getDcFormat() {
     return dcFormat;
   }

--- a/src/main/resources/db/changelog/db.changelog-init.xml
+++ b/src/main/resources/db/changelog/db.changelog-init.xml
@@ -42,7 +42,7 @@
 			<column name="bucket" type="VARCHAR(50)">
 			    <constraints nullable="false" />
 			</column>
-			<column name="dc_format" type="VARCHAR(50)" />
+			<column name="dc_format" type="VARCHAR(150)" />
 			<column name="dc_type" type="dctype">
 				<constraints nullable="false" />
 			</column>


### PR DESCRIPTION
Increased dc_format to 150 characters, changed the init schema directly since there is no release yet.