### PR TITLE
bug_18585_bump_checkstyle_version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script:
   - psql -f src/test/resources/create-test-users.sql -U postgres
 
 script: 
-  - mvn dependency:resolve
   - mvn verify -Dspring.datasource.url=jdbc:postgresql://localhost/object_store_test -Dspring.datasource.username=test -Dspring.datasource.password=test checkstyle:check com.github.spotbugs:spotbugs-maven-plugin:check jacoco:check
  
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - psql -f src/test/resources/create-test-users.sql -U postgres
 
 script: 
-  - mvn verify -Dspring.datasource.url=jdbc:postgresql://localhost/object_store_test -Dspring.datasource.username=test -Dspring.datasource.password=test checkstyle:check com.github.spotbugs:spotbugs-maven-plugin:check jacoco:check
+  - mvn verify -U -Dspring.datasource.url=jdbc:postgresql://localhost/object_store_test -Dspring.datasource.username=test -Dspring.datasource.password=test checkstyle:check com.github.spotbugs:spotbugs-maven-plugin:check jacoco:check
  
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_script:
   - psql -f src/test/resources/create-test-users.sql -U postgres
 
 script: 
-  - mvn verify -U -Dspring.datasource.url=jdbc:postgresql://localhost/object_store_test -Dspring.datasource.username=test -Dspring.datasource.password=test checkstyle:check com.github.spotbugs:spotbugs-maven-plugin:check jacoco:check
+  - mvn dependency:resolve
+  - mvn verify -Dspring.datasource.url=jdbc:postgresql://localhost/object_store_test -Dspring.datasource.username=test -Dspring.datasource.password=test checkstyle:check com.github.spotbugs:spotbugs-maven-plugin:check jacoco:check
  
 jdk:
   - openjdk8

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -94,6 +94,16 @@ limitations under the License.
       <property name="severity" value="ignore"/>
     </module>
 
+      <!-- Checks for Size Violations.                    -->
+      <!-- See http://checkstyle.sf.net/config_sizes.html -->
+      <module name="LineLength">
+        <property name="max" value="100"/>
+        <!-- Ignore import statements and javadoc comments and variables -->
+        <property name="ignorePattern" value='^(import.*$|^ *\*( |[^\/]) *.*)|((.*)=( |)"(.*)"(.*))'/>
+        <!-- severity is at ignore until we fix the other issues -->
+        <property name="severity" value="ignore"/>
+      </module>
+      
     <module name="TreeWalker">
     
       <!-- Indent Checks -->    
@@ -151,7 +161,7 @@ limitations under the License.
         <property name="severity" value="error"/>
       </module>
       <module name="MissingDeprecated">
-        <property name="severity" value="error"/>
+        <property name="severity" value="warning"/>
       </module>
       <module name="MissingOverride">
         <property name="severity" value="error"/>
@@ -164,19 +174,11 @@ limitations under the License.
       <!-- See http://checkstyle.sf.net/config_javadoc.html -->
       <module name="JavadocMethod">
       <property name="severity" value="ignore"/>
-        <!-- don't require javadoc for methods shorter than or equal to
-        this many lines (including opening & closing brace lines) -->
-        <property name="minLineCount" value="5"/>
 
         <!-- javadoc doesn't need one @param, @return, @throws tags -->
         <property name="scope" value="public"/>
-      <property name="allowUndeclaredRTE" value="true"/>
         <property name="allowMissingParamTags" value="true"/>
-        <property name="allowMissingThrowsTags" value="true"/>
         <property name="allowMissingReturnTag" value="true"/>
-
-        <!-- simple set/get methods don't need javadoc comments -->
-        <property name="allowMissingPropertyJavadoc" value="true" />
 
         <!-- Allow tags for runtime exceptions that are not explicitly declared -->
 
@@ -275,16 +277,6 @@ limitations under the License.
                  ca.gc.aafc. Each group should be separated by a single blank line." />
       </module>
 
-      <!-- Checks for Size Violations.                    -->
-      <!-- See http://checkstyle.sf.net/config_sizes.html -->
-      <module name="LineLength">
-        <property name="max" value="100"/>
-        <!-- Ignore import statements and javadoc comments and variables -->
-        <property name="ignorePattern" value='^(import.*$|^ *\*( |[^\/]) *.*)|((.*)=( |)"(.*)"(.*))'/>
-        <!-- severity is at ignore until we fix the other issues -->
-        <property name="severity" value="ignore"/>
-      </module>
-      
       <module name="OuterTypeNumber"/>
 
       <!-- Checks for whitespace                               -->

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<dependency-check-maven.version>5.2.1</dependency-check-maven.version>
 		<jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
 		<maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
-		<checkstyle.version>8.23</checkstyle.version>
+		<checkstyle.version>8.29</checkstyle.version>
 		<asciidoctor-maven-plugin.version>1.5.7.1</asciidoctor-maven-plugin.version>
 		<asciidoctorj.diagram.version>1.5.18</asciidoctorj.diagram.version>
 		<justify.version>0.17.0</justify.version>


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/18585

- Update pom version

Checkstyle\
- move line length module
- remove minLineCount, allowUndeclaredRTE, allowMissingThrowsTags, allowMissingPropertyJavadoc
- lower MissingDeprecated to warning