### PR TITLE
Bug #18447 Some tests failing on Windows

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/minio/MinioFileService.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/minio/MinioFileService.java
@@ -3,11 +3,13 @@ package ca.gc.aafc.objectstore.api.minio;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -57,15 +59,26 @@ public class MinioFileService implements FileInformationService {
   }
   
   /**
+   * Utility method that can turn a {@link Path} into a Minio object name. {@link Path} is different
+   * depending on the OS but the Minio object name will always be the same.
+   * 
+   * @param path
+   * @return minio object name
+   */
+  public static String toMinioObjectName(Path path) {
+    Objects.requireNonNull(path);
+    return Streams.stream(path.iterator()).map(p -> p.getFileName().toString())
+        .collect(Collectors.joining("/"));
+  }
+  
+  /**
    * Return the file location following the {@link FolderStructureStrategy}
    * 
    * @param filename
    * @return
    */
   private String getFileLocation(String filename) {
-    return Streams.stream(folderStructureStrategy.getPathFor(filename).iterator())
-        .map(p -> p.getFileName().toString())
-        .collect(Collectors.joining("/"));
+    return toMinioObjectName(folderStructureStrategy.getPathFor(filename));
   }
   
   private static boolean isNotFoundException(ErrorResponseException erEx) {

--- a/src/test/java/ca/gc/aafc/objectstore/api/TestConfiguration.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/TestConfiguration.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ca.gc.aafc.objectstore.api.file.FileMetaEntry;
 import ca.gc.aafc.objectstore.api.file.FolderStructureStrategy;
+import ca.gc.aafc.objectstore.api.minio.MinioFileService;
 import io.minio.MinioClient;
 import io.minio.ObjectStat;
 import io.minio.ResponseHeader;
@@ -111,7 +112,8 @@ public class TestConfiguration {
       throws InvalidKeyException, InvalidBucketNameException, NoSuchAlgorithmException,
       NoResponseException, ErrorResponseException, InternalException, InvalidArgumentException,
       InsufficientDataException, InvalidResponseException, IOException, XmlPullParserException {
-    minioClient.putObject(TEST_BUCKET, folderStructureStrategy.getPathFor(id + objExt).toString(),
+    minioClient.putObject(TEST_BUCKET,
+        MinioFileService.toMinioObjectName(folderStructureStrategy.getPathFor(id + objExt)),
         objStream, null, null, null, MediaType.TEXT_PLAIN_VALUE);
 
     FileMetaEntry fme = new FileMetaEntry(id);
@@ -122,8 +124,9 @@ public class TestConfiguration {
     String jsonContent = OBJECT_MAPPER.writeValueAsString(fme);
     InputStream metaStream = new ByteArrayInputStream(jsonContent.getBytes(StandardCharsets.UTF_8));
     minioClient.putObject(TEST_BUCKET,
-        folderStructureStrategy.getPathFor(id + FileMetaEntry.SUFFIX).toString(), metaStream, null,
-        null, null, mediaType);
+        MinioFileService
+            .toMinioObjectName(folderStructureStrategy.getPathFor(id + FileMetaEntry.SUFFIX)),
+        metaStream, null, null, null, mediaType);
   }
   
   /**


### PR DESCRIPTION
TestConfiguration was using the toString of Path which is platform dependant. Changed it to use the Minio object name instead.