### PR TITLE
19459 find all by group

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<junit-platform-launcher.version>1.4.0</junit-platform-launcher.version>
 		<hibernate-types-52.version>2.9.3</hibernate-types-52.version>
 		<crnk.version>3.2.20200419165537</crnk.version>
-		<dina-base-api.version>0.29-SNAPSHOT</dina-base-api.version>
+		<dina-base-api.version>0.29</dina-base-api.version>
 
 		<spring-boot-maven-plugin.fork>false</spring-boot-maven-plugin.fork>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<junit-platform-launcher.version>1.4.0</junit-platform-launcher.version>
 		<hibernate-types-52.version>2.9.3</hibernate-types-52.version>
 		<crnk.version>3.2.20200419165537</crnk.version>
-		<dina-base-api.version>0.27</dina-base-api.version>
+		<dina-base-api.version>0.29-SNAPSHOT</dina-base-api.version>
 
 		<spring-boot-maven-plugin.fork>false</spring-boot-maven-plugin.fork>
 	</properties>

--- a/src/main/java/ca/gc/aafc/objectstore/api/respository/ObjectStoreResourceRepository.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/respository/ObjectStoreResourceRepository.java
@@ -124,6 +124,8 @@ public class ObjectStoreResourceRepository extends JpaResourceRepository<ObjectS
     if (authenticatedUser.isPresent()) {
       String firstGroup = authenticatedUser.get().getGroups().stream().findFirst()
           .orElseThrow(() -> new UnauthorizedException("You must belong to a group"));
+      //Key cloak is returning groups with forward prefixed with forward slashes
+      firstGroup = firstGroup.charAt(0) == '/' ? firstGroup.substring(1): firstGroup;
       jpaFriendlyQuerySpec.addFilter(PathSpec.of("bucket").filter(FilterOperator.EQ, firstGroup));
     }
 

--- a/src/main/java/ca/gc/aafc/objectstore/api/respository/ObjectStoreResourceRepository.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/respository/ObjectStoreResourceRepository.java
@@ -124,8 +124,6 @@ public class ObjectStoreResourceRepository extends JpaResourceRepository<ObjectS
     if (authenticatedUser.isPresent()) {
       String firstGroup = authenticatedUser.get().getGroups().stream().findFirst()
           .orElseThrow(() -> new UnauthorizedException("You must belong to a group"));
-      //Key cloak is returning groups with forward prefixed with forward slashes
-      firstGroup = firstGroup.charAt(0) == '/' ? firstGroup.substring(1): firstGroup;
       jpaFriendlyQuerySpec.addFilter(PathSpec.of("bucket").filter(FilterOperator.EQ, firstGroup));
     }
 

--- a/src/test/java/ca/gc/aafc/objectstore/api/DinaAuthenticatedUserConfig.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/DinaAuthenticatedUserConfig.java
@@ -1,0 +1,22 @@
+package ca.gc.aafc.objectstore.api;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
+
+@Configuration
+public class DinaAuthenticatedUserConfig {
+
+  public static final String USER_NAME = "test_user";
+  public static final Set<String> GROUPS = ImmutableSet.of(TestConfiguration.TEST_BUCKET, "Group 2");
+
+  @Bean
+  public DinaAuthenticatedUser dinaAuthenticatedUser() {
+    return DinaAuthenticatedUser.builder().username(USER_NAME).groups(GROUPS).build();
+  }
+}


### PR DESCRIPTION
Metadata find all uses first group of a key cloak user and matches that against the bucket to retrieve the metadata.

The bucket a user uploads a file to must match their first group. In this case the first group was 'aafc'