### PR TITLE
19513 upload file UUID error

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/file/FileController.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/file/FileController.java
@@ -94,10 +94,11 @@ public class FileController {
 
     // Temporary, we will need to check if the user is an admin
     minioService.ensureBucketExists(bucket);
-    authenticateBucket(bucket);
 
     // Check that the UUID is not already assigned.
     UUID uuid = getNewUUID(bucket);
+
+    authenticateBucket(bucket);
 
     MediaTypeDetectionStrategy.MediaTypeDetectionResult mtdr = mediaTypeDetectionStrategy
         .detectMediaType(file.getInputStream(), file.getContentType(), file.getOriginalFilename());

--- a/src/main/java/ca/gc/aafc/objectstore/api/file/FileController.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/file/FileController.java
@@ -92,12 +92,12 @@ public class FileController {
       RegionConflictException, InvalidEndpointException, InvalidPortException, IOException,
       XmlPullParserException, URISyntaxException, MimeTypeException {
 
-    // Check that the UUID is not already assigned.
-    UUID uuid = getNewUUID(bucket);
-    authenticateBucket(bucket);
-
     // Temporary, we will need to check if the user is an admin
     minioService.ensureBucketExists(bucket);
+    authenticateBucket(bucket);
+
+    // Check that the UUID is not already assigned.
+    UUID uuid = getNewUUID(bucket);
 
     MediaTypeDetectionStrategy.MediaTypeDetectionResult mtdr = mediaTypeDetectionStrategy
         .detectMediaType(file.getInputStream(), file.getContentType(), file.getOriginalFilename());


### PR DESCRIPTION
There is an importance of order between these two methods. One method relies on the side effects of another. 
```
    // Temporary, we will need to check if the user is an admin
    minioService.ensureBucketExists(bucket);

    // Check that the UUID is not already assigned.
    UUID uuid = getNewUUID(bucket);
```
Also getNewUUID has a side effect to validate bucket chars, which is tied into the IT tests, so we must authenticate after the two methods have executed.
