### PR TITLE
Support #19900 Managed attribute description should be mandatory

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
@@ -1,6 +1,7 @@
 package ca.gc.aafc.objectstore.api.entities;
 
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -12,20 +13,22 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 
-import ca.gc.aafc.dina.entity.DinaEntity;
-
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.NaturalIdCache;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
+import ca.gc.aafc.dina.entity.DinaEntity;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -60,6 +63,7 @@ public class ManagedAttribute implements DinaEntity {
 
   @Type(type = "jsonb")
   @Column(name = "description", columnDefinition = "jsonb")
+  @NotEmpty
   public Map<String, String> getDescription() {
     return description;
   }
@@ -130,8 +134,22 @@ public class ManagedAttribute implements DinaEntity {
   }
 
   @PrePersist
-  public void initUuid() {
+  public void prePersist() {
     this.uuid = UUID.randomUUID();
+    this.cleanDescription();
+  }
+
+  @PreUpdate
+  public void preUpdate() {
+    this.cleanDescription();
+  }
+
+  /** Cleans empty strings out of the description. */
+  private void cleanDescription() {
+    if (this.description != null) {
+      this.description = new HashMap<>(this.description);
+      this.description.entrySet().removeIf(entry -> StringUtils.isBlank(entry.getValue()));
+    }
   }
 
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -11,4 +11,5 @@
   <include file="db/changelog/migrations/8-drop_agent_table.xml" />
   <include file="db/changelog/migrations/9-Add_xmpRightsUsageTerms_to_metadata.xml" />  
   <include file="db/changelog/migrations/10-Add_Javers_audit_tables.xml"/>  
+  <include file="db/changelog/migrations/11-MakeManagedAttribute-description-mandatory.xml"/>  
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/11-MakeManagedAttribute-description-mandatory.xml
+++ b/src/main/resources/db/changelog/migrations/11-MakeManagedAttribute-description-mandatory.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
+  objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+	<changeSet id="11-MakeManagedAttribute-description-mandatory" context="schema-change" author="poffm">
+    <addNotNullConstraint tableName="managed_attribute" columnName="description" />
+  </changeSet>  
+</databaseChangeLog>

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ManagedAttributeCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ManagedAttributeCRUDIT.java
@@ -4,8 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.validation.ConstraintViolationException;
 
 import com.google.common.collect.ImmutableMap;
+
+import org.junit.jupiter.api.Test;
 
 import ca.gc.aafc.objectstore.api.entities.ManagedAttribute;
 import ca.gc.aafc.objectstore.api.testsupport.factories.ManagedAttributeFactory;
@@ -24,6 +29,18 @@ public class ManagedAttributeCRUDIT extends BaseEntityCRUDIT {
     assertNull(managedAttributeUnderTest.getId());
     service.save(managedAttributeUnderTest);
     assertNotNull(managedAttributeUnderTest.getId());
+  }
+
+  @Test
+  public void testSave_whenDescriptionIsBlank_throwConstraintError() {
+    ManagedAttribute blankDescription = ManagedAttributeFactory.newManagedAttribute()
+      .acceptedValues(new String[] { "a", "b" })
+      .description(ImmutableMap.of("en", ""))
+      .build();
+
+    assertThrows(
+      ConstraintViolationException.class,
+      () -> service.save(blankDescription));
   }
 
   @Override

--- a/src/test/java/ca/gc/aafc/objectstore/api/testsupport/factories/ManagedAttributeFactory.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/testsupport/factories/ManagedAttributeFactory.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.BiFunction;
 
+import com.google.common.collect.ImmutableMap;
+
 import ca.gc.aafc.objectstore.api.entities.ManagedAttribute;
 import ca.gc.aafc.objectstore.api.entities.ManagedAttribute.ManagedAttributeType;
 import ca.gc.aafc.dina.testsupport.factories.TestableEntityFactory;
@@ -25,6 +27,7 @@ public class ManagedAttributeFactory implements TestableEntityFactory<ManagedAtt
     return ManagedAttribute.builder()
         .uuid(UUID.randomUUID())
         .name(TestableEntityFactory.generateRandomNameLettersOnly(12))
+        .description(ImmutableMap.of("en", "test description"))
         .managedAttributeType(ManagedAttributeType.STRING);
    } 
   


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/19900

-Added @NotEmpty annotation to description field.
-Added pre-create/update method to remove the blank fields from the description map, so the map will be empty if the language-specific fields are blank.
-Added test for the @NotEmpty description.