### PR TITLE
19888 add created by and created on managed attribute

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/dto/ManagedAttributeDto.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/dto/ManagedAttributeDto.java
@@ -31,7 +31,7 @@ public class ManagedAttributeDto {
   private String[] acceptedValues;
   private OffsetDateTime createdDate;
   private OffsetDateTime createdOn;
-
+  private String createdBy;
   private Map<String, String> description;
 
 }

--- a/src/main/java/ca/gc/aafc/objectstore/api/dto/ManagedAttributeDto.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/dto/ManagedAttributeDto.java
@@ -30,6 +30,7 @@ public class ManagedAttributeDto {
   private ManagedAttributeType managedAttributeType;
   private String[] acceptedValues;
   private OffsetDateTime createdDate;
+  private OffsetDateTime createdOn;
 
   private Map<String, String> description;
 

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
@@ -56,6 +56,7 @@ public class ManagedAttribute implements DinaEntity {
   private ManagedAttributeType managedAttributeType;
   private String[] acceptedValues;
   private OffsetDateTime createdOn;
+  private String createdBy;
   private Map<String, String> description;
 
   @Type(type = "jsonb")
@@ -137,6 +138,15 @@ public class ManagedAttribute implements DinaEntity {
 
   public void setCreatedOn(OffsetDateTime createdOn) {
     this.createdOn = createdOn;
+  }
+
+  @Column(name = "created_by")
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
   }
 
   @PrePersist

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
@@ -14,6 +14,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -45,20 +46,16 @@ import lombok.RequiredArgsConstructor;
 @NaturalIdCache
 public class ManagedAttribute implements DinaEntity {
 
-  private Integer id;
-  private UUID uuid;
-
-  private String name;
-  private ManagedAttributeType managedAttributeType;
-
-  private String[] acceptedValues;
-
-  private OffsetDateTime createdDate;
-
   public enum ManagedAttributeType {
     INTEGER, STRING
   }
 
+  private Integer id;
+  private UUID uuid;
+  private String name;
+  private ManagedAttributeType managedAttributeType;
+  private String[] acceptedValues;
+  private OffsetDateTime createdOn;
   private Map<String, String> description;
 
   @Type(type = "jsonb")
@@ -124,13 +121,22 @@ public class ManagedAttribute implements DinaEntity {
     this.acceptedValues = acceptedValues;
   }
 
-  @Column(name = "created_date", insertable = false, updatable = false)
+  @Transient
   public OffsetDateTime getCreatedDate() {
-    return createdDate;
+    return createdOn;
   }
 
-  public void setCreatedDate(OffsetDateTime createdDate) {
-    this.createdDate = createdDate;
+  public void setCreatedDate(OffsetDateTime createdOn) {
+    this.createdOn = createdOn;
+  }
+
+  @Column(name = "created_on", insertable = false, updatable = false)
+  public OffsetDateTime getCreatedOn() {
+    return createdOn;
+  }
+
+  public void setCreatedOn(OffsetDateTime createdOn) {
+    this.createdOn = createdOn;
   }
 
   @PrePersist

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
@@ -15,6 +15,7 @@ import javax.persistence.Id;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Transient;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -142,7 +143,8 @@ public class ManagedAttribute implements DinaEntity {
     this.createdOn = createdOn;
   }
 
-  @Column(name = "created_by")
+  @NotBlank
+  @Column(name = "created_by", updatable = false)
   public String getCreatedBy() {
     return createdBy;
   }

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ManagedAttribute.java
@@ -123,10 +123,12 @@ public class ManagedAttribute implements DinaEntity {
   }
 
   @Transient
+  @Deprecated
   public OffsetDateTime getCreatedDate() {
     return createdOn;
   }
 
+  @Deprecated
   public void setCreatedDate(OffsetDateTime createdOn) {
     this.createdOn = createdOn;
   }

--- a/src/main/java/ca/gc/aafc/objectstore/api/respository/ManagedAttributeResourceRepository.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/respository/ManagedAttributeResourceRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import ca.gc.aafc.dina.filter.DinaFilterResolver;
 import ca.gc.aafc.dina.mapper.DinaMapper;
 import ca.gc.aafc.dina.repository.DinaRepository;
+import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
 import ca.gc.aafc.dina.service.DinaService;
 import ca.gc.aafc.objectstore.api.dto.ManagedAttributeDto;
 import ca.gc.aafc.objectstore.api.entities.ManagedAttribute;
@@ -16,9 +17,12 @@ import lombok.NonNull;
 public class ManagedAttributeResourceRepository
     extends DinaRepository<ManagedAttributeDto, ManagedAttribute> {
 
+  private Optional<DinaAuthenticatedUser> authenticatedUser;
+
   public ManagedAttributeResourceRepository(
     @NonNull DinaService<ManagedAttribute> dinaService,
-    @NonNull DinaFilterResolver filterResolver
+    @NonNull DinaFilterResolver filterResolver,
+    Optional<DinaAuthenticatedUser> authenticatedUser
   ) {
     super(
       dinaService,
@@ -26,6 +30,13 @@ public class ManagedAttributeResourceRepository
       new DinaMapper<>(ManagedAttributeDto.class),
       ManagedAttributeDto.class,
       ManagedAttribute.class, filterResolver);
+    this.authenticatedUser = authenticatedUser;
+  }
+
+  @Override
+  public <S extends ManagedAttributeDto> S create(S resource) {
+    authenticatedUser.ifPresent(user -> resource.setCreatedBy(user.getUsername()));
+    return super.create(resource);
   }
 
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -13,4 +13,5 @@
   <include file="db/changelog/migrations/10-Add_Javers_audit_tables.xml"/>  
   <include file="db/changelog/migrations/11-subtype_add_app_managed.xml" />  
   <include file="db/changelog/migrations/12-MakeManagedAttribute-description-mandatory.xml"/>  
+  <include file="db/changelog/migrations/13-managed_attribute_add_createdBy_createdOn.xml"/>  
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/13-managed_attribute_add_createdBy_createdOn.xml
+++ b/src/main/resources/db/changelog/migrations/13-managed_attribute_add_createdBy_createdOn.xml
@@ -13,7 +13,9 @@
 
     <!-- Add created by column -->
     <addColumn tableName="managed_attribute">
-      <column name="created_by" type="VARCHAR(250)" />
+      <column name="created_by" type="VARCHAR(250)">
+        <constraints nullable="false" />
+      </column>
     </addColumn>
 
   </changeSet>

--- a/src/main/resources/db/changelog/migrations/13-managed_attribute_add_createdBy_createdOn.xml
+++ b/src/main/resources/db/changelog/migrations/13-managed_attribute_add_createdBy_createdOn.xml
@@ -5,10 +5,17 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd" objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
 
   <changeSet id="13-managed_attribute_add_createdBy_createdOn" context="schema-change" author="keyuk">
+
     <!-- Rename created_date to created_on -->
     <renameColumn tableName="managed_attribute"
             newColumnName="created_on"  
             oldColumnName="created_date" />  
+
+    <!-- Add created by column -->
+    <addColumn tableName="managed_attribute">
+      <column name="created_by" type="VARCHAR(250)" />
+    </addColumn>
+
   </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/13-managed_attribute_add_createdBy_createdOn.xml
+++ b/src/main/resources/db/changelog/migrations/13-managed_attribute_add_createdBy_createdOn.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no" ?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd" objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+  <changeSet id="13-managed_attribute_add_createdBy_createdOn" context="schema-change" author="keyuk">
+    <!-- Rename created_date to created_on -->
+    <renameColumn tableName="managed_attribute"
+            newColumnName="created_on"  
+            oldColumnName="created_date" />  
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ManagedAttributeCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ManagedAttributeCRUDIT.java
@@ -53,6 +53,7 @@ public class ManagedAttributeCRUDIT extends BaseEntityCRUDIT {
 
     assertEquals("attrFr", managedAttributeUnderTest.getDescription().get("fr"));
     assertNotNull(fetchedObjectStoreMeta.getCreatedDate());
+    assertNotNull(fetchedObjectStoreMeta.getCreatedOn());
   }
 
   @Override

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ManagedAttributeCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ManagedAttributeCRUDIT.java
@@ -20,6 +20,7 @@ public class ManagedAttributeCRUDIT extends BaseEntityCRUDIT {
   private ManagedAttribute managedAttributeUnderTest = ManagedAttributeFactory.newManagedAttribute()
       .acceptedValues(new String[] { "a", "b" })
       .description(ImmutableMap.of("en", "attrEn", "fr", "attrFr"))
+      .createdBy("createdBy")
       .build();
   
 
@@ -52,6 +53,7 @@ public class ManagedAttributeCRUDIT extends BaseEntityCRUDIT {
     assertArrayEquals(new String[] { "a", "b" }, managedAttributeUnderTest.getAcceptedValues());
 
     assertEquals("attrFr", managedAttributeUnderTest.getDescription().get("fr"));
+    assertEquals(managedAttributeUnderTest.getCreatedBy(), fetchedObjectStoreMeta.getCreatedBy());
     assertNotNull(fetchedObjectStoreMeta.getCreatedDate());
     assertNotNull(fetchedObjectStoreMeta.getCreatedOn());
   }

--- a/src/test/java/ca/gc/aafc/objectstore/api/repository/ManagedAttributeRepositoryCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/repository/ManagedAttributeRepositoryCRUDIT.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.UUID;
+
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +14,10 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 
+import ca.gc.aafc.objectstore.api.DinaAuthenticatedUserConfig;
 import ca.gc.aafc.objectstore.api.dto.ManagedAttributeDto;
 import ca.gc.aafc.objectstore.api.entities.ManagedAttribute;
+import ca.gc.aafc.objectstore.api.entities.ManagedAttribute.ManagedAttributeType;
 import ca.gc.aafc.objectstore.api.respository.ManagedAttributeResourceRepository;
 import ca.gc.aafc.objectstore.api.testsupport.factories.ManagedAttributeFactory;
 import io.crnk.core.queryspec.QuerySpec;
@@ -24,12 +28,13 @@ public class ManagedAttributeRepositoryCRUDIT extends BaseRepositoryTest {
   private ManagedAttributeResourceRepository managedResourceRepository;
   
   private ManagedAttribute testManagedAttribute;
-  
+
+  private final static String DINA_USER_NAME = DinaAuthenticatedUserConfig.USER_NAME;
+
   private ManagedAttribute createTestManagedAttribute() throws JsonProcessingException {
     testManagedAttribute = ManagedAttributeFactory.newManagedAttribute()
         .acceptedValues(new String[] { "dosal" })
         .description(ImmutableMap.of("en", "attrEn", "fr", "attrFr"))
-        .createdBy("createdBy")
         .build();
 
     persist(testManagedAttribute);
@@ -54,7 +59,21 @@ public class ManagedAttributeRepositoryCRUDIT extends BaseRepositoryTest {
     assertEquals(testManagedAttribute.getName(), managedAttributeDto.getName());
     assertEquals(testManagedAttribute.getDescription().get("en"),
         managedAttributeDto.getDescription().get("en"));
-    assertEquals(testManagedAttribute.getCreatedBy(), managedAttributeDto.getCreatedBy());
+  }
+
+  @Test
+  public void create_WithAuthenticatedUser_SetsCreatedBy() {
+    ManagedAttributeDto ma = new ManagedAttributeDto();
+    ma.setUuid(UUID.randomUUID());
+    ma.setName("name");
+    ma.setManagedAttributeType(ManagedAttributeType.STRING);
+    ma.setAcceptedValues(new String[] { "dosal" });
+    ma.setDescription(ImmutableMap.of("en", "attrEn", "fr", "attrFr"));
+
+    ManagedAttributeDto result = managedResourceRepository.findOne(
+      managedResourceRepository.create(ma).getUuid(),
+      new QuerySpec(ManagedAttributeDto.class));
+    assertEquals(DINA_USER_NAME, result.getCreatedBy());
   }
     
 }

--- a/src/test/java/ca/gc/aafc/objectstore/api/repository/ManagedAttributeRepositoryCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/repository/ManagedAttributeRepositoryCRUDIT.java
@@ -29,6 +29,7 @@ public class ManagedAttributeRepositoryCRUDIT extends BaseRepositoryTest {
     testManagedAttribute = ManagedAttributeFactory.newManagedAttribute()
         .acceptedValues(new String[] { "dosal" })
         .description(ImmutableMap.of("en", "attrEn", "fr", "attrFr"))
+        .createdBy("createdBy")
         .build();
 
     persist(testManagedAttribute);
@@ -53,6 +54,7 @@ public class ManagedAttributeRepositoryCRUDIT extends BaseRepositoryTest {
     assertEquals(testManagedAttribute.getName(), managedAttributeDto.getName());
     assertEquals(testManagedAttribute.getDescription().get("en"),
         managedAttributeDto.getDescription().get("en"));
+    assertEquals(testManagedAttribute.getCreatedBy(), managedAttributeDto.getCreatedBy());
   }
     
 }

--- a/src/test/java/ca/gc/aafc/objectstore/api/rest/ManagedAttributeJsonApiIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/rest/ManagedAttributeJsonApiIT.java
@@ -38,6 +38,7 @@ public class ManagedAttributeJsonApiIT extends BaseJsonApiIntegrationTest {
     managedAttribute.setAcceptedValues(acceptedValues);
     managedAttribute.setName(TestableEntityFactory.generateRandomNameLettersOnly(12));
     managedAttribute.setManagedAttributeType(ManagedAttributeType.STRING);
+    managedAttribute.setCreatedBy("createdBy");
     Map<String, String> desc = new HashMap<String, String>();
     desc.put("fr", "fr_desc");
     desc.put("en", "en_desc");

--- a/src/test/java/ca/gc/aafc/objectstore/api/rest/ManagedAttributeJsonApiIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/rest/ManagedAttributeJsonApiIT.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import ca.gc.aafc.dina.testsupport.factories.TestableEntityFactory;
+import ca.gc.aafc.objectstore.api.DinaAuthenticatedUserConfig;
 import ca.gc.aafc.objectstore.api.dto.ManagedAttributeDto;
 import ca.gc.aafc.objectstore.api.entities.ManagedAttribute.ManagedAttributeType;
 
@@ -14,6 +15,7 @@ public class ManagedAttributeJsonApiIT extends BaseJsonApiIntegrationTest {
   private static final String SCHEMA_NAME = "ManagedAttribute";
   private static final String RESOURCE_UNDER_TEST = "managed-attribute";
   private static final String SCHEMA_PATH = "DINA-Web/object-store-specs/master/schema/managedAttribute.yaml";  
+  private final static String DINA_USER_NAME = DinaAuthenticatedUserConfig.USER_NAME;
 
   @Override
   protected String getSchemaName() {
@@ -38,7 +40,7 @@ public class ManagedAttributeJsonApiIT extends BaseJsonApiIntegrationTest {
     managedAttribute.setAcceptedValues(acceptedValues);
     managedAttribute.setName(TestableEntityFactory.generateRandomNameLettersOnly(12));
     managedAttribute.setManagedAttributeType(ManagedAttributeType.STRING);
-    managedAttribute.setCreatedBy("createdBy");
+    managedAttribute.setCreatedBy(DINA_USER_NAME);
     Map<String, String> desc = new HashMap<String, String>();
     desc.put("fr", "fr_desc");
     desc.put("en", "en_desc");

--- a/src/test/java/ca/gc/aafc/objectstore/api/testsupport/factories/ManagedAttributeFactory.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/testsupport/factories/ManagedAttributeFactory.java
@@ -28,6 +28,7 @@ public class ManagedAttributeFactory implements TestableEntityFactory<ManagedAtt
         .uuid(UUID.randomUUID())
         .name(TestableEntityFactory.generateRandomNameLettersOnly(12))
         .description(ImmutableMap.of("en", "test description"))
+        .createdBy("createdBy")
         .managedAttributeType(ManagedAttributeType.STRING);
    } 
   


### PR DESCRIPTION
1. Renames created date column to created on.
2. Add created on field to managed attribute dto and entity.
3. Remove created date field from entity but keep getters and setters so the field will remain on the response for now.
4. Entity class will share the created ON field for created date getters and setters.
5. Adds Created By column 


Testing:
You can post a new managed attribute send a GET request for it and you can see the columns working as expected.