### PR TITLE
20320 liquibase migration 18 fail

### DIFF
--- a/src/main/resources/db/changelog/migrations/18-Add_FileMetaEntry_to_object_upload_table.xml
+++ b/src/main/resources/db/changelog/migrations/18-Add_FileMetaEntry_to_object_upload_table.xml
@@ -7,58 +7,69 @@
     <changeSet id="18-Add_FileMetaEntry_to_object_upload_table" context="schema-change" author="ganx">
         <!-- Add Original file name column -->
         <addColumn tableName="object_upload">
-            <column name="original_filename" type="VARCHAR(250)" >
-                <constraints nullable="false" />
-            </column>
+            <column name="original_filename" type="VARCHAR(250)"/>
         </addColumn>
 
         <!-- Add sha1Hex column -->
         <addColumn tableName="object_upload">
-            <column name="sha1_hex" type="VARCHAR(128)" >
-                <constraints nullable="false" />
-            </column>
+            <column name="sha1_hex" type="VARCHAR(128)"/>
         </addColumn>
 
         <!-- Add receivedMediaType column -->
         <addColumn tableName="object_upload">
-            <column name="received_media_type" type="VARCHAR(150)" />
+            <column name="received_media_type" type="VARCHAR(150)"/>
         </addColumn>
 
         <!-- Add detectedMediaType column -->
         <addColumn tableName="object_upload">
-            <column name="detected_media_type" type="VARCHAR(150)" />
+            <column name="detected_media_type" type="VARCHAR(150)"/>
         </addColumn>
 
         <!-- Add detectedFileExtension column -->
         <addColumn tableName="object_upload">
-            <column name="detected_file_extension" type="VARCHAR(10)" />
+            <column name="detected_file_extension" type="VARCHAR(10)"/>
         </addColumn>
 
         <!-- Add evaluatedMediaType column -->
         <addColumn tableName="object_upload">
-            <column name="evaluated_media_type" type="VARCHAR(150)" />
+            <column name="evaluated_media_type" type="VARCHAR(150)"/>
         </addColumn>
 
         <!-- Add evaluatedFileExtension column -->
         <addColumn tableName="object_upload">
-            <column name="evaluated_file_extension" type="VARCHAR(10)" />
+            <column name="evaluated_file_extension" type="VARCHAR(10)"/>
         </addColumn>
-      
+
         <!-- Add sizeInBytes column -->
         <addColumn tableName="object_upload">
-            <column name="size_in_bytes" type="BIGINT" />
+            <column name="size_in_bytes" type="BIGINT"/>
         </addColumn>
 
         <!-- Add thumbnailIdentifier column -->
         <addColumn tableName="object_upload">
-            <column name="thumbnail_identifier" type="uuid" />
+            <column name="thumbnail_identifier" type="uuid"/>
         </addColumn>
 
         <!-- Add bucket name column -->
         <addColumn tableName="object_upload">
-            <column name="bucket" type="VARCHAR(50)" >
-                <constraints nullable="false" />
-            </column>
+            <column name="bucket" type="VARCHAR(50)"/>
         </addColumn>
+
+        <!-- Update not null columns with a default value  -->
+        <update tableName="object_upload">
+            <column name="original_filename" value="original_filename_Add_Column_Migration"/>
+        </update>
+        <update tableName="object_upload">
+            <column name="sha1_hex" value="sha1_hex_Add_Column_Migration"/>
+        </update>
+        <update tableName="object_upload">
+            <column name="bucket" value="bucket_Add_Column_Migration"/>
+        </update>
+
+        <!-- Add not null constraint to columns -->
+        <addNotNullConstraint tableName="object_upload" columnName="original_filename"/>
+        <addNotNullConstraint tableName="object_upload" columnName="sha1_hex"/>
+        <addNotNullConstraint tableName="object_upload" columnName="bucket"/>
+
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Adjust migration to account for old records when adding not not null constraints

Original stack trace 

> Caused by: liquibase.exception.MigrationFailedException: Migration failed for change set db/changelog/migrations/18-Add_FileMetaEntry_to_object_upload_table.xml::18-Add_FileMetaEntry_to_object_upload_table::ganx:
     Reason: liquibase.exception.DatabaseException: ERROR: column "original_filename" contains null values [Failed SQL: (0) ALTER TABLE object_store.object_upload ADD original_filename VARCHAR(250) NOT NULL]