### PR TITLE
Support #19508 Clarify FileController getNewUUID method

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/file/FileInformationService.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/file/FileInformationService.java
@@ -18,18 +18,6 @@ public interface FileInformationService {
    * @return
    */
   boolean bucketExists(String bucketName);
-
-  /**
-   * Check if at least 1 object in the provided bucket starts with a specific prefix. 
-   * 
-   * @param bucketName
-   * @param fileNamePrefix
-   * @return at least 1 object with the provided prefix exists
-   * @throws IllegalStateException if something wrong with the request or response. For example, invalid bucket name.
-   * @throws IOException
-   */
-  boolean isFileWithPrefixExists(String bucketName, String fileNamePrefix)
-      throws IllegalStateException, IOException;
   
   /**
    * Get information about a file as {@link FileObjectInfo}.
@@ -41,15 +29,5 @@ public interface FileInformationService {
    * @throws IOException
    */
   Optional<FileObjectInfo> getFileInfo(String fileName, String bucketName) throws IOException;
-  
-  /**
-   * Read and return a json file as an instance of the provided class.
-   * @param bucketName
-   * @param filename
-   * @param clazz
-   * @return
-   * @throws IOException
-   */
-  <T> Optional<T> getJsonFileContentAs(String bucketName, String filename, Class<T> clazz) throws IOException;
 
 }

--- a/src/test/java/ca/gc/aafc/objectstore/api/file/FileUploadIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/file/FileUploadIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import io.crnk.core.exception.UnauthorizedException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -39,7 +40,7 @@ public class FileUploadIT extends BaseIntegrationTest {
   }
 
   @Test
-  public void fileUpload_onInvalidBucket_returnError() throws Exception {
+  public void fileUpload_onInvalidBucket_returnUnauthorizedException() throws Exception {
 
     MockMultipartFile file = new MockMultipartFile("file", "testfile", MediaType.TEXT_PLAIN_VALUE,
         "Test Content".getBytes());
@@ -52,7 +53,7 @@ public class FileUploadIT extends BaseIntegrationTest {
     }
     // NestedServletException is a generic exception so we want to do the assertion on the cause
     catch (NestedServletException nsEx) {
-      assertEquals(IllegalStateException.class, nsEx.getCause().getClass());
+      assertEquals(UnauthorizedException.class, nsEx.getCause().getClass());
     }
      
   }


### PR DESCRIPTION
Renamed method getNewUUID to something more clear. The method will also rely on the database instead of scanning Minio objects prefix.
By doing that a lot of code becomes dead and have been removed.