### PR TITLE
20959 meta orphans removed on delete

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
@@ -317,7 +317,7 @@ public class ObjectStoreMetadata implements SoftDeletable, DinaEntity {
     this.xmpRightsOwner = xmpRightsOwner;
   }
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "ac_derived_from_id", referencedColumnName = "id")
   public ObjectStoreMetadata getAcDerivedFrom() {
     return acDerivedFrom;
@@ -334,7 +334,7 @@ public class ObjectStoreMetadata implements SoftDeletable, DinaEntity {
     this.acDerivedFrom = acDerivedFrom;
   }
 
-  @OneToMany(mappedBy = "acDerivedFrom", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "acDerivedFrom", cascade = {CascadeType.PERSIST})
   public List<ObjectStoreMetadata> getDerivatives() {
     return derivatives;
   }

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
@@ -149,7 +149,7 @@ public class ObjectStoreMetadata implements SoftDeletable, DinaEntity {
   /**
    * Returns fileIdentifier + fileExtension
    * 
-   * @return
+   * @return fileIdentifier + fileExtension
    */
   @Transient
   public String getFilename() {
@@ -323,6 +323,13 @@ public class ObjectStoreMetadata implements SoftDeletable, DinaEntity {
     return acDerivedFrom;
   }
 
+  /**
+   * Sets the acDerived from value. Note to establish and remove a bi directional relationship, the
+   * {@link ObjectStoreMetadata#addDerivative} and {@link ObjectStoreMetadata#removeDerivative}
+   * methods should be called from the parent.
+   *
+   * @param acDerivedFrom - parent to set
+   */
   public void setAcDerivedFrom(ObjectStoreMetadata acDerivedFrom) {
     this.acDerivedFrom = acDerivedFrom;
   }
@@ -336,11 +343,23 @@ public class ObjectStoreMetadata implements SoftDeletable, DinaEntity {
     this.derivatives = derivatives;
   }
 
+  /**
+   * Adds the given derivative to the list of derivatives. This method should be used to establish
+   * Bi directional JPA relations ships.
+   *
+   * @param derivative - derivative to add
+   */
   public void addDerivative(ObjectStoreMetadata derivative) {
     derivatives.add(derivative);
     derivative.setAcDerivedFrom(this);
   }
 
+  /**
+   * Adds the given derivative to the list of derivatives. This method should be used to remove Bi
+   * directional JPA relations ships.
+   *
+   * @param derivative - derivative to remove
+   */
   public void removeDerivative(ObjectStoreMetadata derivative) {
     derivatives.remove(derivative);
     derivative.setAcDerivedFrom(null);

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
@@ -334,7 +334,7 @@ public class ObjectStoreMetadata implements SoftDeletable, DinaEntity {
     this.acDerivedFrom = acDerivedFrom;
   }
 
-  @OneToMany(mappedBy = "acDerivedFrom", cascade = {CascadeType.PERSIST})
+  @OneToMany(mappedBy = "acDerivedFrom", cascade = CascadeType.PERSIST)
   public List<ObjectStoreMetadata> getDerivatives() {
     return derivatives;
   }

--- a/src/main/java/ca/gc/aafc/objectstore/api/service/ObjectStoreMetaDataService.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/service/ObjectStoreMetaDataService.java
@@ -6,6 +6,7 @@ import ca.gc.aafc.objectstore.api.entities.ObjectStoreMetadata;
 import ca.gc.aafc.objectstore.api.entities.ObjectSubtype;
 import ca.gc.aafc.objectstore.api.resolvers.ObjectStoreMetaDataFieldResolvers;
 import lombok.NonNull;
+import org.apache.commons.collections.CollectionUtils;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
@@ -45,6 +46,13 @@ public class ObjectStoreMetaDataService extends DefaultDinaService<ObjectStoreMe
       baseDAO.update(entity);
 
       setAcSubType(entity, temp);
+    }
+  }
+
+  @Override
+  protected void preDelete(ObjectStoreMetadata entity) {
+    if (CollectionUtils.isNotEmpty(entity.getDerivatives())) {
+      entity.getDerivatives().forEach(derived -> derived.setAcDerivedFrom(null));
     }
   }
 

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
@@ -116,7 +116,6 @@ public class ObjectStoreMetadataEntityCRUDIT extends BaseEntityCRUDIT {
     ObjectStoreMetadata parent = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
     ObjectStoreMetadata child = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
 
-    metaService.create(child);
     parent.addDerivative(child);
     metaService.create(parent);
 

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
@@ -9,8 +9,8 @@ import ca.gc.aafc.objectstore.api.testsupport.factories.ManagedAttributeFactory;
 import ca.gc.aafc.objectstore.api.testsupport.factories.MetadataManagedAttributeFactory;
 import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectStoreMetadataFactory;
 import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectSubtypeFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
@@ -39,8 +39,8 @@ public class ObjectStoreMetadataEntityCRUDIT extends BaseEntityCRUDIT {
       .acDigitizationDate(TEST_OFFSET_DT)
       .build();
 
-  @AfterEach
-  void tearDown() {
+  @BeforeEach
+  void setUp() {
     // Clean all database entries
     metaService.findAll(ObjectStoreMetadata.class,
       (criteriaBuilder, objectStoreMetadataRoot) -> new Predicate[0],

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
@@ -142,6 +142,7 @@ public class ObjectStoreMetadataEntityCRUDIT extends BaseEntityCRUDIT {
     Assertions.assertNotNull(resultChild);
     Assertions.assertNull(resultChild.getAcDerivedFrom());
   }
+
   @Test
   public void testRelationships() {
     ManagedAttribute ma = ManagedAttributeFactory.newManagedAttribute().build();

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
+import javax.persistence.criteria.Predicate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -119,13 +120,28 @@ public class ObjectStoreMetadataEntityCRUDIT extends BaseEntityCRUDIT {
     parent.addDerivative(child);
     metaService.create(parent);
 
+    // Needed to force a flush, also proves amount of total meta in the db
+    Assertions.assertEquals(2, metaService.findAll(ObjectStoreMetadata.class,
+      (criteriaBuilder, objectStoreMetadataRoot) -> new Predicate[0],
+      null, 0, 100).size());
+
     Assertions.assertNotNull(metaService.findOne(child.getUuid(), ObjectStoreMetadata.class));
 
     metaService.delete(parent);
-    Assertions.assertNull(metaService.findOne(parent.getUuid(), ObjectStoreMetadata.class));
-    Assertions.assertNotNull(metaService.findOne(child.getUuid(), ObjectStoreMetadata.class));
-  }
 
+    // Needed to force a flush, also proves amount of total meta in the db
+    Assertions.assertEquals(1, metaService.findAll(ObjectStoreMetadata.class,
+      (criteriaBuilder, objectStoreMetadataRoot) -> new Predicate[0],
+      null, 0, 100).size());
+
+    Assertions.assertNull(metaService.findOne(parent.getUuid(), ObjectStoreMetadata.class));
+
+    ObjectStoreMetadata resultChild = metaService.findOne(
+      child.getUuid(),
+      ObjectStoreMetadata.class);
+    Assertions.assertNotNull(resultChild);
+    Assertions.assertNull(resultChild.getAcDerivedFrom());
+  }
   @Test
   public void testRelationships() {
     ManagedAttribute ma = ManagedAttributeFactory.newManagedAttribute().build();

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
@@ -9,6 +9,7 @@ import ca.gc.aafc.objectstore.api.testsupport.factories.ManagedAttributeFactory;
 import ca.gc.aafc.objectstore.api.testsupport.factories.MetadataManagedAttributeFactory;
 import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectStoreMetadataFactory;
 import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectSubtypeFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,14 @@ public class ObjectStoreMetadataEntityCRUDIT extends BaseEntityCRUDIT {
       .dcCreator(UUID.randomUUID())
       .acDigitizationDate(TEST_OFFSET_DT)
       .build();
+
+  @AfterEach
+  void tearDown() {
+    // Clean all database entries
+    metaService.findAll(ObjectStoreMetadata.class,
+      (criteriaBuilder, objectStoreMetadataRoot) -> new Predicate[0],
+      null, 0, 100).forEach(metaService::delete);
+  }
 
   @Override
   public void testSave() {


### PR DESCRIPTION
Fixes an issue where orphan derivatives were being deleted.

We can now prove in the tests that through the usage of the Dina Service and the tweaks to the cascading types, the children are in fact not deleted.

https://vladmihalcea.com/jpa-hibernate-synchronize-bidirectional-entity-associations/