### PR TITLE
22233 update derivatives on metadata

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/dto/ObjectStoreMetadataDto.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/dto/ObjectStoreMetadataDto.java
@@ -97,12 +97,8 @@ public class ObjectStoreMetadataDto {
   private ExternalRelationDto acMetadataCreator;
 
   @JsonApiRelation
-  @ShallowReference
-  private ObjectStoreMetadataDto acDerivedFrom;
-
-  @JsonApiRelation
   @DiffIgnore
-  private List<ObjectStoreMetadataDto> derivatives = new ArrayList<>();
+  private List<DerivativeDto> derivatives = new ArrayList<>();
 
   @JsonApiExternalRelation(type = "person")
   @JsonApiRelation

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
@@ -63,9 +63,7 @@ public class ObjectStoreMetadata extends AbstractObjectStoreMetadata implements 
   private UUID acMetadataCreator;
   private UUID dcCreator;
 
-  private ObjectStoreMetadata acDerivedFrom;
-
-  private List<ObjectStoreMetadata> derivatives;
+  private List<Derivative> derivatives;
 
   private Boolean publiclyReleasable;
   private String notPubliclyReleasableReason;
@@ -103,8 +101,7 @@ public class ObjectStoreMetadata extends AbstractObjectStoreMetadata implements 
     List<MetadataManagedAttribute> managedAttribute,
     UUID acMetadataCreator,
     UUID dcCreator,
-    ObjectStoreMetadata acDerivedFrom,
-    List<ObjectStoreMetadata> derivatives,
+    List<Derivative> derivatives,
     Boolean publiclyReleasable,
     String notPubliclyReleasableReason,
     ObjectSubtype acSubType,
@@ -135,7 +132,6 @@ public class ObjectStoreMetadata extends AbstractObjectStoreMetadata implements 
     this.managedAttribute = CollectionUtils.isNotEmpty(managedAttribute) ? managedAttribute : new ArrayList<>();
     this.acMetadataCreator = acMetadataCreator;
     this.dcCreator = dcCreator;
-    this.acDerivedFrom = acDerivedFrom;
     this.derivatives = CollectionUtils.isNotEmpty(derivatives) ? derivatives : new ArrayList<>();
     this.publiclyReleasable = publiclyReleasable;
     this.notPubliclyReleasableReason = notPubliclyReleasableReason;
@@ -285,52 +281,13 @@ public class ObjectStoreMetadata extends AbstractObjectStoreMetadata implements 
     this.xmpRightsOwner = xmpRightsOwner;
   }
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "ac_derived_from_id", referencedColumnName = "id")
-  public ObjectStoreMetadata getAcDerivedFrom() {
-    return acDerivedFrom;
-  }
-
-  /**
-   * Sets the acDerived from value. Note to establish and remove a bi directional relationship, the {@link
-   * ObjectStoreMetadata#addDerivative} and {@link ObjectStoreMetadata#removeDerivative} methods should be
-   * called from the parent.
-   *
-   * @param acDerivedFrom - parent to set
-   */
-  public void setAcDerivedFrom(ObjectStoreMetadata acDerivedFrom) {
-    this.acDerivedFrom = acDerivedFrom;
-  }
-
   @OneToMany(mappedBy = "acDerivedFrom", cascade = CascadeType.PERSIST)
-  public List<ObjectStoreMetadata> getDerivatives() {
+  public List<Derivative> getDerivatives() {
     return derivatives;
   }
 
-  public void setDerivatives(List<ObjectStoreMetadata> derivatives) {
+  public void setDerivatives(List<Derivative> derivatives) {
     this.derivatives = derivatives;
-  }
-
-  /**
-   * Adds the given derivative to the list of derivatives. This method should be used to establish Bi
-   * directional JPA relations ships.
-   *
-   * @param derivative - derivative to add
-   */
-  public void addDerivative(ObjectStoreMetadata derivative) {
-    derivatives.add(derivative);
-    derivative.setAcDerivedFrom(this);
-  }
-
-  /**
-   * Adds the given derivative to the list of derivatives. This method should be used to remove Bi directional
-   * JPA relations ships.
-   *
-   * @param derivative - derivative to remove
-   */
-  public void removeDerivative(ObjectStoreMetadata derivative) {
-    derivatives.remove(derivative);
-    derivative.setAcDerivedFrom(null);
   }
 
   @Column(name = "publicly_releasable")

--- a/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/entities/ObjectStoreMetadata.java
@@ -290,6 +290,28 @@ public class ObjectStoreMetadata extends AbstractObjectStoreMetadata implements 
     this.derivatives = derivatives;
   }
 
+  /**
+   * Adds the given derivative to the list of derivatives. This method should be used to establish Bi
+   * directional JPA relations ships.
+   *
+   * @param derivative - derivative to add
+   */
+  public void addDerivative(Derivative derivative) {
+    derivatives.add(derivative);
+    derivative.setAcDerivedFrom(this);
+  }
+
+  /**
+   * Adds the given derivative to the list of derivatives. This method should be used to remove Bi directional
+   * JPA relations ships.
+   *
+   * @param derivative - derivative to remove
+   */
+  public void removeDerivative(Derivative derivative) {
+    derivatives.remove(derivative);
+    derivative.setAcDerivedFrom(null);
+  }
+
   @Column(name = "publicly_releasable")
   public Boolean getPubliclyReleasable() {
     return publiclyReleasable;

--- a/src/main/java/ca/gc/aafc/objectstore/api/service/DerivativeService.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/service/DerivativeService.java
@@ -19,6 +19,18 @@ public class DerivativeService extends DefaultDinaService<Derivative> {
   @Override
   protected void preCreate(Derivative entity) {
     entity.setUuid(UUID.randomUUID());
+    establishBiDirectionalAssociation(entity);
+  }
+
+  @Override
+  protected void preUpdate(Derivative entity) {
+    establishBiDirectionalAssociation(entity);
+  }
+
+  private static void establishBiDirectionalAssociation(Derivative entity) {
+    if (entity.getAcDerivedFrom() != null) {
+      entity.getAcDerivedFrom().addDerivative(entity);
+    }
   }
 
   public Optional<Derivative> findByFileId(UUID fileId) {
@@ -27,6 +39,5 @@ public class DerivativeService extends DefaultDinaService<Derivative> {
         null, 0, 1)
         .stream().findFirst();
   }
-
 
 }

--- a/src/main/java/ca/gc/aafc/objectstore/api/service/ObjectStoreMetaDataService.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/service/ObjectStoreMetaDataService.java
@@ -8,7 +8,7 @@ import ca.gc.aafc.objectstore.api.entities.ObjectSubtype;
 import ca.gc.aafc.objectstore.api.file.ThumbnailService;
 import io.crnk.core.exception.BadRequestException;
 import lombok.NonNull;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
@@ -55,9 +55,6 @@ public class ObjectStoreMetaDataService extends DefaultDinaService<ObjectStoreMe
       setAcSubType(entity, entity.getAcSubType());
     }
 
-    if (entity.getAcDerivedFrom() != null) {
-      entity.getAcDerivedFrom().addDerivative(entity);
-    }
   }
 
   @Override
@@ -90,9 +87,6 @@ public class ObjectStoreMetaDataService extends DefaultDinaService<ObjectStoreMe
       baseDAO.update(entity);
 
       setAcSubType(entity, temp);
-    }
-    if (entity.getAcDerivedFrom() != null) {
-      entity.getAcDerivedFrom().addDerivative(entity);
     }
   }
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -26,4 +26,5 @@
   <include file="db/changelog/migrations/23-Add_derivative_entity.xml"/>
   <include file="db/changelog/migrations/24-ObjectUpload_track_isDerivative.xml"/>
   <include file="db/changelog/migrations/25-remove_subtype_from_derivative.xml"/>
+  <include file="db/changelog/migrations/26-update_derivatives_on_metadata.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/26-update_derivatives_on_metadata.xml
+++ b/src/main/resources/db/changelog/migrations/26-update_derivatives_on_metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no" ?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
+                   objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="26-update_derivatives_on_metadata" context="schema-change" author="KeyukJ">
+        <!--   Drop  ac_derived_from_id column   -->
+        <dropForeignKeyConstraint baseTableName="metadata" constraintName="fk_metadata_ac_derived_from_id"/>
+        <dropColumn tableName="metadata" columnName="ac_derived_from_id"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/DerivativeCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/DerivativeCRUDIT.java
@@ -59,6 +59,8 @@ public class DerivativeCRUDIT extends BaseEntityCRUDIT {
     Integer id = derivative.getId();
     derivativeService.delete(derivative);
     Assertions.assertNull(service.find(Derivative.class, id));
+    // Child should still exist
+    Assertions.assertNotNull(service.find(ObjectStoreMetadata.class, metadata.getId()));
   }
 
   /**

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/DerivativeCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/DerivativeCRUDIT.java
@@ -3,36 +3,32 @@ package ca.gc.aafc.objectstore.api.crud;
 import ca.gc.aafc.objectstore.api.entities.DcType;
 import ca.gc.aafc.objectstore.api.entities.Derivative;
 import ca.gc.aafc.objectstore.api.entities.ObjectStoreMetadata;
+import ca.gc.aafc.objectstore.api.service.DerivativeService;
+import ca.gc.aafc.objectstore.api.service.ObjectStoreMetaDataService;
 import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectStoreMetadataFactory;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 public class DerivativeCRUDIT extends BaseEntityCRUDIT {
+
+  @Inject
+  private ObjectStoreMetaDataService metaService;
+  @Inject
+  private DerivativeService derivativeService;
 
   private Derivative derivative;
   private final ObjectStoreMetadata metadata = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
 
   @BeforeEach
   void setUp() {
-    service.save(metadata);
-    derivative = Derivative.builder()
-      .uuid(UUID.randomUUID())
-      .fileIdentifier(UUID.randomUUID())
-      .fileExtension(".jpg")
-      .bucket("mybucket")
-      .acHashValue("abc")
-      .acHashFunction("abcFunction")
-      .dcType(DcType.IMAGE)
-      .createdBy(RandomStringUtils.random(4))
-      .acDerivedFrom(metadata)
-      .derivativeType(Derivative.DerivativeType.THUMBNAIL_IMAGE)
-      .build();
-    service.save(derivative);
+    metaService.create(metadata);
+    derivative = newDerivative(metadata);
+    derivativeService.create(derivative);
   }
 
   @Override
@@ -61,8 +57,40 @@ public class DerivativeCRUDIT extends BaseEntityCRUDIT {
   @Override
   public void testRemove() {
     Integer id = derivative.getId();
-    service.deleteById(Derivative.class, id);
-    assertNull(service.find(Derivative.class, id));
+    derivativeService.delete(derivative);
+    Assertions.assertNull(service.find(Derivative.class, id));
   }
 
+  /**
+   * This test case is required because a child is currently only soft deleted, so we need to establish the
+   * relation is removed.
+   */
+  @Test
+  void delete_WhenChildDeleted_RelationRemoved() {
+    ObjectStoreMetadata child = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
+    metaService.create(child);
+
+    Derivative parent = newDerivative(child);
+    derivativeService.create(parent);
+
+    metaService.delete(service.find(ObjectStoreMetadata.class, child.getId()));
+    Derivative result = service.find(Derivative.class, parent.getId());
+
+    Assertions.assertNull(result.getAcDerivedFrom());
+  }
+
+  private Derivative newDerivative(ObjectStoreMetadata child) {
+    return Derivative.builder()
+      .uuid(UUID.randomUUID())
+      .fileIdentifier(UUID.randomUUID())
+      .fileExtension(".jpg")
+      .bucket("mybucket")
+      .acHashValue("abc")
+      .acHashFunction("abcFunction")
+      .dcType(DcType.IMAGE)
+      .createdBy(RandomStringUtils.random(4))
+      .acDerivedFrom(child)
+      .derivativeType(Derivative.DerivativeType.THUMBNAIL_IMAGE)
+      .build();
+  }
 }

--- a/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/crud/ObjectStoreMetadataEntityCRUDIT.java
@@ -84,68 +84,6 @@ public class ObjectStoreMetadataEntityCRUDIT extends BaseEntityCRUDIT {
   }
 
   @Test
-  void test_AddingDerivatives_RelationShipEstablished() {
-    ObjectStoreMetadata parent = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
-    ObjectStoreMetadata child = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
-
-    parent.addDerivative(child);
-    metaService.create(parent);
-
-    ObjectStoreMetadata resultChild = service.find(ObjectStoreMetadata.class, child.getId());
-    ObjectStoreMetadata resultParent = service.find(ObjectStoreMetadata.class, parent.getId());
-
-    Assertions.assertEquals(resultChild.getAcDerivedFrom().getId(), resultParent.getId());
-
-    List<ObjectStoreMetadata> resultDerivatives = resultParent.getDerivatives();
-    Assertions.assertEquals(1, resultDerivatives.size());
-    Assertions.assertEquals(resultChild.getId(), resultDerivatives.get(0).getId());
-  }
-
-  @Test
-  void test_RemovingDerivatives_RelationRemoved() {
-    ObjectStoreMetadata parent = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
-    ObjectStoreMetadata child = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
-    parent.addDerivative(child);
-    metaService.create(parent);
-
-    ObjectStoreMetadata update = service.find(ObjectStoreMetadata.class, parent.getId());
-    update.removeDerivative(service.find(ObjectStoreMetadata.class, child.getId()));
-    metaService.update(parent);
-
-    ObjectStoreMetadata resultChild = service.find(ObjectStoreMetadata.class, child.getId());
-    ObjectStoreMetadata resultParent = service.find(ObjectStoreMetadata.class, parent.getId());
-
-    Assertions.assertNull(resultChild.getAcDerivedFrom());
-    Assertions.assertEquals(0, resultParent.getDerivatives().size());
-  }
-
-  @Test
-  void test_DeleteParent_ChildrenNotDeleted() {
-    ObjectStoreMetadata parent = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
-    ObjectStoreMetadata child = ObjectStoreMetadataFactory.newObjectStoreMetadata().build();
-
-    parent.addDerivative(child);
-    metaService.create(parent);
-
-    // Needed to force a flush
-    fetchAllMeta();
-    Assertions.assertNotNull(metaService.findOne(child.getUuid(), ObjectStoreMetadata.class));
-    Assertions.assertNotNull(metaService.findOne(parent.getUuid(), ObjectStoreMetadata.class));
-
-    metaService.delete(parent);
-
-    // Needed to force a flush
-    fetchAllMeta();
-    //Parent is soft deleted
-    Assertions.assertNotNull(
-      metaService.findOne(parent.getUuid(), ObjectStoreMetadata.class).getDeletedDate());
-
-    ObjectStoreMetadata resultChild = metaService.findOne(child.getUuid(), ObjectStoreMetadata.class);
-    Assertions.assertNotNull(resultChild);
-    Assertions.assertNull(resultChild.getAcDerivedFrom());
-  }
-
-  @Test
   public void testRelationships() {
     ManagedAttribute ma = ManagedAttributeFactory.newManagedAttribute().build();
     service.save(ma, false);

--- a/src/test/java/ca/gc/aafc/objectstore/api/rest/ObjectStoreMetadataJsonApiIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/rest/ObjectStoreMetadataJsonApiIT.java
@@ -1,29 +1,26 @@
 package ca.gc.aafc.objectstore.api.rest;
 
+import ca.gc.aafc.objectstore.api.MinioTestConfiguration;
+import ca.gc.aafc.objectstore.api.dto.ObjectStoreMetadataDto;
+import ca.gc.aafc.objectstore.api.entities.ObjectStoreMetadata;
+import ca.gc.aafc.objectstore.api.entities.ObjectSubtype;
+import ca.gc.aafc.objectstore.api.entities.ObjectUpload;
+import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectSubtypeFactory;
+import io.restassured.response.ValidatableResponse;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import ca.gc.aafc.objectstore.api.MinioTestConfiguration;
-import ca.gc.aafc.objectstore.api.dto.ObjectStoreMetadataDto;
-import ca.gc.aafc.objectstore.api.entities.ObjectStoreMetadata;
-import ca.gc.aafc.objectstore.api.entities.ObjectSubtype;
-import ca.gc.aafc.objectstore.api.entities.ObjectUpload;
-import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectStoreMetadataFactory;
-import ca.gc.aafc.objectstore.api.testsupport.factories.ObjectSubtypeFactory;
-import io.restassured.response.ValidatableResponse;
-import org.springframework.http.HttpStatus;
-
 public class ObjectStoreMetadataJsonApiIT extends BaseJsonApiIntegrationTest {
 
-  private static final String METADATA_DERIVED_PROPERTY_NAME = "acDerivedFrom";
   private static final String SCHEMA_NAME = "Metadata";
   private static final String RESOURCE_UNDER_TEST = "metadata";
   
@@ -31,17 +28,9 @@ public class ObjectStoreMetadataJsonApiIT extends BaseJsonApiIntegrationTest {
   private ObjectSubtype oSubtype;
   private ObjectUpload oUpload;
 
-  private UUID metadataId;
-  
   @BeforeEach
   public void setup() {
     oUpload = MinioTestConfiguration.buildTestObjectUpload();
-
-    // used to test relationships
-    ObjectStoreMetadata metadata = ObjectStoreMetadataFactory
-      .newObjectStoreMetadata()
-      .fileIdentifier(UUID.randomUUID())
-      .build();
 
     oSubtype = ObjectSubtypeFactory
       .newObjectSubtype()
@@ -50,12 +39,10 @@ public class ObjectStoreMetadataJsonApiIT extends BaseJsonApiIntegrationTest {
     // we need to run the setup in another transaction and commit it otherwise it can't be visible
     // to the test web server.
     service.runInNewTransaction(em -> {
-      em.persist(metadata);
       em.persist(oSubtype);
       em.persist(oUpload);
     });
 
-    metadataId = metadata.getUuid();
   }
 
   /**
@@ -127,7 +114,6 @@ public class ObjectStoreMetadataJsonApiIT extends BaseJsonApiIntegrationTest {
   @Override
   protected List<Relationship> buildRelationshipList() {
     return Arrays.asList(
-      Relationship.of(METADATA_DERIVED_PROPERTY_NAME, "metadata", metadataId.toString()),
       Relationship.of("dcCreator", "person", UUID.randomUUID().toString()),
       Relationship.of("acMetadataCreator", "person", UUID.randomUUID().toString()));
   }


### PR DESCRIPTION
- Drop acDerivedFrom from metadata entity
- Update derivatives from metadata entity to point to the derivative resource.
- Move test cases to Parents Crud IT