### PR TITLE
22450 postgres 9.6 compliant

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-init.xml
+++ b/src/main/resources/db/changelog/db.changelog-init.xml
@@ -406,15 +406,15 @@
                                  referencedColumnNames="id" referencedTableName="object_subtype" validate="true"/>
     </changeSet>
     <changeSet context="schema-change" author="jon (generated)" id="1618574483518-38">
-        <createSequence cacheSize="1" cycle="false" dataType="bigint" incrementBy="1" maxValue="9223372036854775807"
+        <createSequence cacheSize="1" cycle="false"  incrementBy="1" maxValue="9223372036854775807"
                         minValue="1" sequenceName="jv_commit_pk_seq" startValue="1"/>
     </changeSet>
     <changeSet context="schema-change" author="jon (generated)" id="1618574483518-39">
-        <createSequence cacheSize="1" cycle="false" dataType="bigint" incrementBy="1" maxValue="9223372036854775807"
+        <createSequence cacheSize="1" cycle="false"  incrementBy="1" maxValue="9223372036854775807"
                         minValue="1" sequenceName="jv_global_id_pk_seq" startValue="1"/>
     </changeSet>
     <changeSet context="schema-change" author="jon (generated)" id="1618574483518-40">
-        <createSequence cacheSize="1" cycle="false" dataType="bigint" incrementBy="1" maxValue="9223372036854775807"
+        <createSequence cacheSize="1" cycle="false"  incrementBy="1" maxValue="9223372036854775807"
                         minValue="1" sequenceName="jv_snapshot_pk_seq" startValue="1"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,7 +10,7 @@ spring:
     contexts: schema-change
 embedded.postgresql:
   enabled: true
-  image: postgres:12.4
+  image: postgres:9.6
   init-script-file: create-test-users.sql
   database: object_store_test
   schema: object_store


### PR DESCRIPTION
- adjust test yml for postgres 9.6
- remove data_type from create sequence statements