### PR TITLE
22285 validate incoming thumbnails as derivatives

### DIFF
--- a/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
@@ -1,0 +1,32 @@
+package ca.gc.aafc.objectstore.api.validation;
+
+import ca.gc.aafc.objectstore.api.entities.Derivative;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Component
+@RequiredArgsConstructor
+public class DerivativeValidator implements Validator {
+
+  private final MessageSource messageSource;
+
+  @Override
+  public boolean supports(@NonNull Class<?> aClass) {
+    return Derivative.class.isAssignableFrom(aClass);
+  }
+
+  @Override
+  public void validate(@NonNull Object o, @NonNull Errors errors) {
+    if (!supports(o.getClass())) {
+      throw new IllegalArgumentException(
+        "this validator only supports the " + Derivative.class.getSimpleName() + " class.");
+    }
+
+    Derivative entity = (Derivative) o;
+
+  }
+}

--- a/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
@@ -15,8 +15,8 @@ import org.springframework.validation.Validator;
 @RequiredArgsConstructor
 public class DerivativeValidator implements Validator {
 
-  public static final String VALID_THUMB_DC_FORMAT_KEY = "";
-  public static final String VALID_THUMB_SUPPORTED_KEY = "";
+  public static final String VALID_THUMB_DC_FORMAT_KEY = "validation.constraint.violation.requiredThumbnailDcFormat";
+  public static final String VALID_THUMB_SUPPORTED_KEY = "validation.constraint.violation.thumbnailDcFormatNotSupported";
 
   private final MessageSource messageSource;
 

--- a/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
@@ -54,7 +54,7 @@ public class DerivativeValidator implements Validator {
 
   private void loadErrorMessageForKey(Errors errors, String key) {
     errors.reject(key, messageSource.getMessage(
-      VALID_THUMB_DC_FORMAT_KEY,
+      key,
       null,
       LocaleContextHolder.getLocale()));
   }

--- a/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidator.java
@@ -1,9 +1,12 @@
 package ca.gc.aafc.objectstore.api.validation;
 
 import ca.gc.aafc.objectstore.api.entities.Derivative;
+import ca.gc.aafc.objectstore.api.file.ThumbnailGenerator;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -11,6 +14,9 @@ import org.springframework.validation.Validator;
 @Component
 @RequiredArgsConstructor
 public class DerivativeValidator implements Validator {
+
+  public static final String VALID_THUMB_DC_FORMAT_KEY = "";
+  public static final String VALID_THUMB_SUPPORTED_KEY = "";
 
   private final MessageSource messageSource;
 
@@ -28,5 +34,28 @@ public class DerivativeValidator implements Validator {
 
     Derivative entity = (Derivative) o;
 
+    validateDerivativeForThumbnail(errors, entity);
+  }
+
+  private void validateDerivativeForThumbnail(@NonNull Errors errors, @NonNull Derivative entity) {
+    boolean isDerivativeForThumbnail = entity.getDerivativeType() != null
+      && entity.getDerivativeType() == Derivative.DerivativeType.THUMBNAIL_IMAGE;
+
+    if (isDerivativeForThumbnail) {
+      if (StringUtils.isBlank(entity.getDcFormat())) {
+        loadErrorMessageForKey(errors, VALID_THUMB_DC_FORMAT_KEY);
+      } else {
+        if (!ThumbnailGenerator.isSupported(entity.getDcFormat())) {
+          loadErrorMessageForKey(errors, VALID_THUMB_SUPPORTED_KEY);
+        }
+      }
+    }
+  }
+
+  private void loadErrorMessageForKey(Errors errors, String key) {
+    errors.reject(key, messageSource.getMessage(
+      VALID_THUMB_DC_FORMAT_KEY,
+      null,
+      LocaleContextHolder.getLocale()));
   }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,3 +1,6 @@
 minio.file_or_bucket_not_found={0} or bucket: {1}  not found
 
 assignedValue.invalid=assignedValue "{0}" is invalid.
+
+validation.constraint.violation.requiredThumbnailDcFormat=A thumbnail can not be submitted without a valid DC Format.
+validation.constraint.violation.thumbnailDcFormatNotSupported=The submitted DC Format is not a supported thumbnail.

--- a/src/test/java/ca/gc/aafc/objectstore/api/service/DerivativeServiceIT.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/service/DerivativeServiceIT.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 
 import javax.inject.Inject;
 import javax.persistence.criteria.Predicate;
+import javax.validation.ValidationException;
 import java.util.List;
 import java.util.UUID;
 
@@ -49,6 +50,14 @@ public class DerivativeServiceIT extends BaseIntegrationTest {
   }
 
   @Test
+  void create_UsesValidator() {
+    Derivative derivative = newDerivative(acDerivedFrom);
+    derivative.setDerivativeType(Derivative.DerivativeType.THUMBNAIL_IMAGE);
+    derivative.setDcFormat(null);
+    Assertions.assertThrows(ValidationException.class, () -> derivativeService.create(derivative));
+  }
+
+  @Test
   void create_WhenDerivativeIsThumbNail_ThumbNailNotGenerated() {
     Derivative derivative = newDerivative(acDerivedFrom);
     derivative.setDerivativeType(Derivative.DerivativeType.THUMBNAIL_IMAGE);
@@ -70,6 +79,14 @@ public class DerivativeServiceIT extends BaseIntegrationTest {
 
     Assertions.assertEquals(1, findAllByDerivative(derivative).size());
     Assertions.assertEquals(0, findAllByDerivative(derivative2).size());
+  }
+
+  @Test
+  void update_UsesValidator() {
+    Derivative derivative = derivativeService.create(newDerivative(acDerivedFrom));
+    derivative.setDerivativeType(Derivative.DerivativeType.THUMBNAIL_IMAGE);
+    derivative.setDcFormat(null);
+    Assertions.assertThrows(ValidationException.class, () -> derivativeService.update(derivative));
   }
 
   @Test

--- a/src/test/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidatorTest.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/validation/DerivativeValidatorTest.java
@@ -1,0 +1,84 @@
+package ca.gc.aafc.objectstore.api.validation;
+
+import ca.gc.aafc.objectstore.api.entities.Derivative;
+import ca.gc.aafc.objectstore.api.repository.BaseRepositoryTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.MediaType;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+
+import javax.inject.Inject;
+import java.util.UUID;
+
+class DerivativeValidatorTest extends BaseRepositoryTest {
+
+  @Inject
+  private DerivativeValidator validator;
+
+  @Inject
+  private MessageSource messageSource;
+
+  @Test
+  void supports() {
+    Assertions.assertTrue(validator.supports(Derivative.class));
+    Assertions.assertFalse(validator.supports(Integer.class));
+  }
+
+  @Test
+  void validate_WhenValidDerivativeForThumbnail_ValidationSuccess() {
+    Derivative derivative = newDerivative();
+
+    Errors errors = new BeanPropertyBindingResult(derivative, derivative.getUuid().toString());
+    validator.validate(derivative, errors);
+    Assertions.assertEquals(0, errors.getAllErrors().size());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"  ", "\t", "\n"})
+  void validate_WhenDerivativeForThumbnail_BlankDcFormat_ErrorsReturned(String input) {
+    String expectedErrorMessage = getExpectedErrorMessage(DerivativeValidator.VALID_THUMB_DC_FORMAT_KEY);
+
+    Derivative derivative = newDerivative();
+    derivative.setDcFormat(input);
+
+    Errors errors = new BeanPropertyBindingResult(derivative, derivative.getUuid().toString());
+    validator.validate(derivative, errors);
+    Assertions.assertEquals(1, errors.getAllErrors().size());
+    Assertions.assertEquals(expectedErrorMessage, errors.getAllErrors().get(0).getDefaultMessage());
+  }
+
+  @Test
+  void validate_WhenDerivativeForThumbnail_UnSupportedDcFormat_ErrorsReturned() {
+    String expectedErrorMessage = getExpectedErrorMessage(DerivativeValidator.VALID_THUMB_SUPPORTED_KEY);
+
+    Derivative derivative = newDerivative();
+    derivative.setDcFormat(MediaType.TEXT_XML_VALUE);
+
+    Errors errors = new BeanPropertyBindingResult(derivative, derivative.getUuid().toString());
+    validator.validate(derivative, errors);
+    Assertions.assertEquals(1, errors.getAllErrors().size());
+    Assertions.assertEquals(expectedErrorMessage, errors.getAllErrors().get(0).getDefaultMessage());
+  }
+
+  private String getExpectedErrorMessage(String key) {
+    return messageSource.getMessage(
+      key,
+      null,
+      LocaleContextHolder.getLocale());
+  }
+
+  private static Derivative newDerivative() {
+    return Derivative.builder()
+      .uuid(UUID.randomUUID())
+      .derivativeType(Derivative.DerivativeType.THUMBNAIL_IMAGE)
+      .dcFormat(MediaType.IMAGE_JPEG_VALUE)
+      .build();
+  }
+}


### PR DESCRIPTION
The main idea was to prevent someone from submitting an unsupported thumbnail.

For example you can not submit a text file to be used as a thumbnail for an object.