### PR TITLE
36666 ObjectExport missing mapper config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,7 @@
               <version>${lombok-mapstruct-binding.version}</version>
             </path>
           </annotationProcessorPaths>
+          <showWarnings>true</showWarnings>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/ca/gc/aafc/objectstore/api/mapper/ObjectExportMapper.java
+++ b/src/main/java/ca/gc/aafc/objectstore/api/mapper/ObjectExportMapper.java
@@ -17,7 +17,9 @@ public interface ObjectExportMapper {
 
   ObjectExportMapper INSTANCE = Mappers.getMapper(ObjectExportMapper.class);
 
-  @Mapping(target = "objectExportOption", source = ".")
+  @Mapping(source = "filenameAliases", target = "objectExportOption.aliases")
+  @Mapping(source = "exportLayout", target = "objectExportOption.exportLayout")
+  @Mapping(source = "exportFunction", target = "objectExportOption.exportFunction")
   ObjectExportService.ExportArgs toEntity(ObjectExportDto dto);
 
   default <T> List<T> nullSafeList(List<T> list) {

--- a/src/test/java/ca/gc/aafc/objectstore/api/mapper/ObjectExportMapperTest.java
+++ b/src/test/java/ca/gc/aafc/objectstore/api/mapper/ObjectExportMapperTest.java
@@ -1,0 +1,41 @@
+package ca.gc.aafc.objectstore.api.mapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import ca.gc.aafc.objectstore.api.config.ExportFunction;
+import ca.gc.aafc.objectstore.api.dto.ObjectExportDto;
+import ca.gc.aafc.objectstore.api.service.ObjectExportService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ObjectExportMapperTest {
+
+  @Test
+  public void testMapping() {
+
+    UUID file1UUID = UUID.randomUUID();
+
+    ObjectExportDto exportDto = ObjectExportDto.builder()
+      .username("Jim")
+      .fileIdentifiers(List.of(file1UUID))
+      .name("my-export")
+      .filenameAliases(Map.of(file1UUID, "alias1"))
+      .exportLayout(Map.of("myfolder", List.of(file1UUID)))
+      .exportFunction(ExportFunction.builder().functionDef(ExportFunction.FunctionDef.IMG_RESIZE).build())
+      .build();
+
+    ObjectExportService.ExportArgs exportArgs = ObjectExportMapper.INSTANCE.toEntity(exportDto);
+
+    assertEquals("alias1", exportArgs.objectExportOption().aliases().get(file1UUID));
+    assertEquals(file1UUID, exportArgs.objectExportOption().exportLayout().get("myfolder").getFirst());
+    assertEquals(ExportFunction.FunctionDef.IMG_RESIZE, exportArgs.objectExportOption().exportFunction().functionDef());
+    assertEquals("Jim", exportArgs.username());
+    assertEquals(file1UUID, exportArgs.fileIdentifiers().getFirst());
+    assertEquals("my-export", exportArgs.name());
+
+  }
+}


### PR DESCRIPTION
Mapping using . to indicate flattening/expanding of nested objects is not working since aliases is not the same name in both classes